### PR TITLE
Add support for GetPayeeDetails API

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ Payoneer::Payee.signup_url('payee_1', redirect_url: 'http://<redirect_url>.com',
 response = Payoneer::Payee.signup_url('payee_1')
 signup_url = response.body if response.ok?
 
+# Get Payee Details
+
+response = Payoneer::Payee.details('payee_1')
+payee = response.body if response.ok?
+p payee["PayeeStatus"]
+
 # Perform Payout for Payee
 response = Payoneer::Payout.create(
   program_id: '<payoneer_program_id>',

--- a/lib/payoneer/payee.rb
+++ b/lib/payoneer/payee.rb
@@ -3,6 +3,7 @@ require 'uri'
 module Payoneer
   class Payee
     SIGNUP_URL_API_METHOD_NAME = 'GetToken'
+    PAYEE_DETAILS_API_METHOD_NAME = 'GetPayeeDetails'
 
     def self.signup_url(payee_id, redirect_url: nil, redirect_time: nil)
       payoneer_params = {
@@ -17,6 +18,20 @@ module Payoneer
 
       if success?(response)
         Response.new_ok_response(response['Token'])
+      else
+        Response.new(response['Code'], response['Description'])
+      end
+    end
+
+    def self.details(payee_id)
+      payoneer_params = {
+        p4: payee_id
+      }
+
+      response = Payoneer.make_api_request(PAYEE_DETAILS_API_METHOD_NAME, payoneer_params)
+
+      if success?(response)
+        Response.new_ok_response(response['Payee'])
       else
         Response.new(response['Code'], response['Description'])
       end

--- a/lib/payoneer/version.rb
+++ b/lib/payoneer/version.rb
@@ -1,3 +1,3 @@
 module Payoneer
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
Given a payee ID, return the payee details or an error if payee ID is unknown.

Specifically used to get the status of a payee to determine if they've successfully setup their account.
